### PR TITLE
[small fix]  update HdfsFileToCosTask.java, fix convertHdfsPathToCos exception

### DIFF
--- a/src/main/java/com/qcloud/hdfs_to_cos/HdfsFileToCosTask.java
+++ b/src/main/java/com/qcloud/hdfs_to_cos/HdfsFileToCosTask.java
@@ -77,7 +77,7 @@ public class HdfsFileToCosTask implements Runnable {
         // hdfs folder path example: hdfs://222:111:333:444:8020/tmp/chengwu/
         if (hdfsFolderPath.startsWith("hdfs://")) {
             hdfsFolderPath =
-                    hdfsFolderPath.substring(hdfsFilePath.indexOf("/", "hdfs://".length()));
+                    hdfsFolderPath.substring(hdfsFolderPath.indexOf("/", "hdfs://".length()));
             // /tmp/chengwu/
         }
 


### PR DESCRIPTION

when hdfs_path starts with  hdfs:///tmp/xxx/ , there was an error occurred:
```
2018-05-30 11:11:05 [ERROR] [pool-4-thread-1:1001] [com.qcloud.hdfs_to_cos.HdfsFileToCosTask:] [HdfsFileToCosTask.java:141] 
 convertHdfsPathToCos occur a exception. hdfsPath: hdfs:///tmp/xxxx, hdfsFilePath: hdfs://10.0.0.35:4007/tmp/xxxx, exception: java.lang.StringIndexOutOfBoundsException: String index out of range: -4
```